### PR TITLE
feat(config): allow for configurable timeout

### DIFF
--- a/lib/downstream.ex
+++ b/lib/downstream.ex
@@ -10,19 +10,26 @@ defmodule Downstream do
 
   @request_timeout 60_000
 
-  @spec get(binary, IO.device(), [{binary, binary}]) :: {atom, binary}
+  @spec get(binary, IO.device(), Keyword.t()) :: {atom, binary}
   @doc ~S"""
   Downloads from a given URL with a GET request.
 
   Returns `{:ok, io_device}` if the download is successful, and `{:error, reason}`
   otherwise.
   """
-  def get(url, io_device, headers \\ []) do
+  def get(url, io_device, options \\ []) do
+    timeout = Keyword.get(options, :timeout, @request_timeout)
+    headers = Keyword.get(options, :headers, [])
+
     download_task = Task.async(Download, :stream, [io_device])
 
     HTTPoison.get!(url, headers, stream_to: download_task.pid)
 
-    Task.await(download_task, @request_timeout)
+    try do
+      Task.await(download_task, timeout)
+    catch
+      :exit, _ -> {:error, "request timeout"}
+    end
   end
 
   @doc ~S"""
@@ -30,37 +37,44 @@ defmodule Downstream do
 
   If the request succeeds, the IO device is returned.
   """
-  @spec get!(binary, IO.device(), [{binary, binary}]) :: binary
-  def get!(url, io_device, headers \\ []) do
-    case get(url, io_device, headers) do
+  @spec get!(binary, IO.device(), Keyword.t()) :: binary
+  def get!(url, io_device, options \\ []) do
+    case get(url, io_device, options) do
       {:error, error} -> raise to_string(error)
       {:ok, io_device} -> io_device
     end
   end
 
-  @spec post(binary, IO.device(), binary | {atom, any}, [{binary, binary}]) :: {atom, binary}
+  @spec post(binary, IO.device(), binary | {atom, any}, Keyword.t()) :: {atom, binary}
   @doc ~S"""
   Downloads from a given URL with a POST request.
 
   Returns `{:ok, io_device}` if the download is successful, and `{:error, reason}`
   otherwise.
   """
-  def post(url, io_device, body \\ "", headers \\ []) do
+  def post(url, io_device, body \\ "", options \\ []) do
+    timeout = Keyword.get(options, :timeout, @request_timeout)
+    headers = Keyword.get(options, :headers, [])
+
     download_task = Task.async(Download, :stream, [io_device])
 
     HTTPoison.post!(url, body, headers, stream_to: download_task.pid)
 
-    Task.await(download_task, @request_timeout)
+    try do
+      Task.await(download_task, timeout)
+    catch
+      :exit, _ -> {:error, "request timeout"}
+    end
   end
 
-  @spec post!(binary, IO.device(), binary | {atom, any}, [{binary, binary}]) :: binary
+  @spec post!(binary, IO.device(), binary | {atom, any}, Keyword.t()) :: binary
   @doc ~S"""
   Downloads from the given URL with a POST request, raising an exception in the case of failure.
 
   If the request succeeds, the IO device is returned.
   """
-  def post!(url, io_device, body \\ "", headers \\ []) do
-    case post(url, io_device, body, headers) do
+  def post!(url, io_device, body \\ "", options \\ []) do
+    case post(url, io_device, body, options) do
       {:error, error} -> raise to_string(error)
       {:ok, io_device} -> io_device
     end

--- a/lib/downstream/download.ex
+++ b/lib/downstream/download.ex
@@ -5,14 +5,10 @@ defmodule Downstream.Download do
 
   alias HTTPoison.{AsyncChunk, AsyncEnd, AsyncHeaders, AsyncStatus}
 
-  @message_timeout 5_000
-
   @spec stream(IO.device()) :: tuple
   def stream(io_device) do
     receive do
       response_chunk -> handle_response_chunk(response_chunk, io_device)
-    after
-      @message_timeout -> {:error, "request timeout"}
     end
   end
 

--- a/test/downstream/download_test.exs
+++ b/test/downstream/download_test.exs
@@ -38,13 +38,5 @@ defmodule Downstream.DownloadTest do
 
       assert Task.await(task) == {:error, "unexpected error"}
     end
-
-    test "times out after 5 seconds of no messages", context do
-      task = Task.async(Download, :stream, [context.io_device])
-
-      Process.sleep(5_000)
-
-      assert Task.await(task) == {:error, "request timeout"}
-    end
   end
 end

--- a/test/downstream_test.exs
+++ b/test/downstream_test.exs
@@ -22,6 +22,12 @@ defmodule DownstreamTest do
     test "returns an error for an unsuccessful download", context do
       assert Downstream.get(@error_url, context.io_device) == {:error, "status code 404"}
     end
+
+    test "accepts a configurable timeout", context do
+      url = "#{@success_url}?sleep=5000"
+
+      assert Downstream.get(url, context.io_device, timeout: 1_000) == {:error, "request timeout"}
+    end
   end
 
   describe "get!/3" do
@@ -61,6 +67,13 @@ defmodule DownstreamTest do
 
     test "returns an error for an unsuccessful download", context do
       assert Downstream.post(@error_url, context.io_device) == {:error, "status code 404"}
+    end
+
+    test "accepts a configurable timeout", context do
+      url = "#{@success_url}?sleep=5000"
+
+      assert Downstream.post(url, context.io_device, "", timeout: 1_000) ==
+               {:error, "request timeout"}
     end
   end
 


### PR DESCRIPTION
**What**

- [x] Removes `@message_timeout` from `Downstream.Download` module, since the timeout in `Downstream` will take precedence.
- [x] Allow `options` keyword list to be passed to `get/3` and `post/4` methods.