### PR TITLE
fix(gitignore): update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,45 @@
-/_build/
-/cover/
-/deps/
-/doc/
+# Created by https://www.gitignore.io/api/macos,elixir
+
+### Elixir ###
+/_build
+/cover
+/deps
+/doc
 /.fetch
 erl_crash.dump
 *.ez
-downstream-*.tar
+*.beam
+/config/*.secret.exs
 
+### Elixir Patch ###
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+# End of https://www.gitignore.io/api/macos,elixir


### PR DESCRIPTION
## What & Why

Updates the `.gitignore` file to use a file generated by [gitignore.io](https://www.gitignore.io/).