### PR TITLE
feat(response): return response object instead of io device on success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ language: elixir
 sudo: false
 
 elixir:
-  - '1.6.1'
-  - '1.7.0'
-  - '1.8.0'
+  - '1.7.4'
+  - '1.8.1'
 
 otp_release:
-  - '20.0'
+  - '21.2'
 
 env:
   - MIX_ENV="test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - mix format --check-formatted --dry-run
   - mix credo
   - mix coveralls.html --max-cases 1
-  - mix dialyzer --halt-exit-status
+  - travis_wait mix dialyzer --halt-exit-status
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 elixir:
   - '1.6.1'
+  - '1.7.0'
+  - '1.8.0'
 
 otp_release:
   - '20.0'
@@ -13,10 +15,10 @@ env:
 
 script:
   - mix compile --warnings-as-errors
-  - mix coveralls.html --max-cases 1
-  - mix credo
-  - mix dialyzer --halt-exit-status
   - mix format --check-formatted --dry-run
+  - mix credo
+  - mix coveralls.html --max-cases 1
+  - mix dialyzer --halt-exit-status
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -29,11 +29,75 @@ end
 Using `Downstream` is simple. Just pass it a URL and an IO device:
 
 ```elixir
-file = File.open!("index.html", [:write])
-
-{:ok, device} = Downstream.get("https://google.com", file)
+iex(1)> file = File.open!("index.html", [:write])
+#PID<0.84.0>
+iex(2)> Downstream.get("https://www.google.com", file)
+{:ok,
+ %Downstream.Response{
+   device: #PID<0.84.0>,
+   error_message: nil,
+   headers: [
+     {"Date", "Sat, 09 Feb 2019 14:25:34 GMT"},
+     {"Expires", "-1"},
+     {"Cache-Control", "private, max-age=0"},
+     {"Content-Type", "text/html; charset=ISO-8859-1"},
+     ...
+     {"Server", "gws"},
+     {"X-XSS-Protection", "1; mode=block"},
+     {"X-Frame-Options", "SAMEORIGIN"},
+     {"Accept-Ranges", "none"},
+     {"Vary", "Accept-Encoding"},
+     {"Transfer-Encoding", "chunked"}
+   ],
+   status_code: 200
+ }}
+iex(3)> File.close(file)
+:ok
 ```
 
+Bang methods are also provided:
+
+```elixir
+iex(1)> file = File.open!("index.html", [:write])
+#PID<0.84.0>
+iex(2)> Downstream.get("https://www.google.com", file)
+%Downstream.Response{
+  device: #PID<0.84.0>,
+  error_message: nil,
+  headers: [
+    {"Date", "Sat, 09 Feb 2019 14:25:34 GMT"},
+    {"Expires", "-1"},
+    {"Cache-Control", "private, max-age=0"},
+    {"Content-Type", "text/html; charset=ISO-8859-1"},
+    ...
+    {"Server", "gws"},
+    {"X-XSS-Protection", "1; mode=block"},
+    {"X-Frame-Options", "SAMEORIGIN"},
+    {"Accept-Ranges", "none"},
+    {"Vary", "Accept-Encoding"},
+    {"Transfer-Encoding", "chunked"}
+  ],
+  status_code: 200
+}}
+iex(3)> File.close(file)
+:ok
+```
+
+`Downstream` currently supports streaming downloads via the `get/2`, `post/2`, `get!/2` and `post!/2` methods. For all non-200 status codes, an error is returned.
+
+```elixir
+iex(1)> file = File.open!("index.html", [:write])
+#PID<0.84.0>
+iex(2)> Downstream.get("https://www.google.com/notfound", file)
+{:error,
+ %Downstream.Error{
+   device: #PID<0.84.0>,
+   reason: :invalid_status_code,
+   status_code: 404
+ }}
+iex(3)> File.close(file)
+:ok
+```
 ## Current Features
 
 - Stream downloads via HTTP GET requests
@@ -42,7 +106,8 @@ file = File.open!("index.html", [:write])
 
 ## Roadmap
 
-- [ ] Add support for callbacks (i.e. header handler, status handler, etc.)
+- [ ] Handle redirects
+- [ ] Allow custom configurations
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ end
 
 ## Usage
 
-Using `Downstream` is simple. Just pass it a URL and an IO device:
+Using `Downstream` is simple. First, start it your application:
+
+```elixir
+Downstream.start()
+```
+
+Then, just pass it a URL and an IO device:
 
 ```elixir
 iex(1)> file = File.open!("index.html", [:write])

--- a/lib/downstream.ex
+++ b/lib/downstream.ex
@@ -10,6 +10,9 @@ defmodule Downstream do
 
   @request_timeout 60_000
 
+  @spec start() :: {atom, any}
+  def start(), do: :application.ensure_all_started(:downstream)
+
   @spec get(binary, IO.device(), Keyword.t()) :: {:ok, Response.t()} | {:error, Error.t()}
   @doc ~S"""
   Downloads from a given URL with a GET request.

--- a/lib/downstream/download.ex
+++ b/lib/downstream/download.ex
@@ -3,37 +3,39 @@ defmodule Downstream.Download do
   The `Downstream.Download` module processes `HTTPoison` asynchronous requests.
   """
 
+  alias Downstream.{Error, Response}
   alias HTTPoison.{AsyncChunk, AsyncEnd, AsyncHeaders, AsyncStatus}
 
-  @spec stream(IO.device()) :: tuple
-  def stream(io_device) do
+  @dialyzer {:no_return, stream: 1, stream: 2}
+
+  def stream(io_device, response \\ %Response{}) do
     receive do
-      response_chunk -> handle_response_chunk(response_chunk, io_device)
+      response_chunk -> handle_response_chunk(response_chunk, io_device, response)
     end
   end
 
-  defp handle_response_chunk(%AsyncStatus{code: 200}, io_device) do
-    stream(io_device)
+  defp handle_response_chunk(%AsyncStatus{code: 200}, io_device, response) do
+    stream(io_device, %Response{response | status_code: 200})
   end
 
-  defp handle_response_chunk(%AsyncStatus{code: code}, _io_device) do
-    {:error, "status code #{code}"}
+  defp handle_response_chunk(%AsyncStatus{code: code}, io_device, _response) do
+    {:error, %Error{device: io_device, reason: :invalid_status_code, status_code: code}}
   end
 
-  defp handle_response_chunk(%AsyncHeaders{headers: _headers}, io_device) do
-    stream(io_device)
+  defp handle_response_chunk(%AsyncHeaders{headers: headers}, io_device, response) do
+    stream(io_device, %Response{response | headers: headers})
   end
 
-  defp handle_response_chunk(%AsyncChunk{chunk: data}, io_device) do
+  defp handle_response_chunk(%AsyncChunk{chunk: data}, io_device, response) do
     IO.binwrite(io_device, data)
-    stream(io_device)
+    stream(io_device, response)
   end
 
-  defp handle_response_chunk(%AsyncEnd{}, io_device) do
-    {:ok, io_device}
+  defp handle_response_chunk(%AsyncEnd{}, io_device, response) do
+    {:ok, %Response{response | device: io_device}}
   end
 
-  defp handle_response_chunk(_, _io_device) do
-    {:error, "unexpected error"}
+  defp handle_response_chunk(_, io_device, _response) do
+    {:error, %Error{device: io_device, reason: :unexpected_error}}
   end
 end

--- a/lib/downstream/error.ex
+++ b/lib/downstream/error.ex
@@ -1,0 +1,11 @@
+defmodule Downstream.Error do
+  @moduledoc """
+  A generic error that is thrown by the `Downstream` library.
+  """
+
+  defexception device: nil, reason: nil, status_code: nil
+
+  @type t :: %__MODULE__{device: IO.device(), reason: any, status_code: non_neg_integer()}
+
+  def message(%__MODULE__{reason: reason}), do: inspect(reason)
+end

--- a/lib/downstream/response.ex
+++ b/lib/downstream/response.ex
@@ -1,0 +1,15 @@
+defmodule Downstream.Response do
+  @moduledoc """
+  The `Downstream.Response` module provides a struct for storing response
+  information, including status code and headers.
+  """
+
+  defstruct device: nil, headers: [], status_code: nil
+
+  @type headers :: [{atom, binary}] | [{binary, binary}] | %{binary => binary} | any
+  @type t :: %__MODULE__{
+          device: IO.device(),
+          headers: headers,
+          status_code: non_neg_integer
+        }
+end

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Downstream.MixProject do
 
   def application do
     [
-      applications: [:httpoison, :logger]
+      applications: [:httpoison]
     ]
   end
 

--- a/test/downstream/error_test.exs
+++ b/test/downstream/error_test.exs
@@ -1,0 +1,11 @@
+defmodule Downstream.ErrorTest do
+  use ExUnit.Case
+
+  alias Downstream.Error
+
+  describe "message/1" do
+    test "returns the reason" do
+      assert Error.message(%Error{reason: :timeout}) == ":timeout"
+    end
+  end
+end

--- a/test/downstream_test.exs
+++ b/test/downstream_test.exs
@@ -2,8 +2,6 @@ defmodule DownstreamTest do
   use ExUnit.Case, async: true
   doctest Downstream
 
-  @tag timeout: 10_000
-
   alias Downstream.Error
 
   @get_success_url "https://s3-us-west-2.amazonaws.com/downstream-test/downstream.txt"

--- a/test/downstream_test.exs
+++ b/test/downstream_test.exs
@@ -1,5 +1,5 @@
 defmodule DownstreamTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   doctest Downstream
 
   alias Downstream.Error

--- a/test/downstream_test.exs
+++ b/test/downstream_test.exs
@@ -2,6 +2,10 @@ defmodule DownstreamTest do
   use ExUnit.Case
   doctest Downstream
 
+  @tag timeout: 5_000
+
+  alias Downstream.Error
+
   @success_url "https://httpstat.us/200"
   @error_url "https://httpstat.us/404"
 
@@ -13,20 +17,25 @@ defmodule DownstreamTest do
     end
 
     test "successfully downloads a file with a get request", context do
-      {:ok, io_device} = Downstream.get(@success_url, context.io_device)
+      {:ok, response} = Downstream.get(@success_url, context.io_device)
 
-      assert io_device == context.io_device
-      assert StringIO.flush(io_device) == "200 OK"
+      assert response.device == context.io_device
+      assert response.status_code == 200
+      assert is_binary(StringIO.flush(response.device))
     end
 
     test "returns an error for an unsuccessful download", context do
-      assert Downstream.get(@error_url, context.io_device) == {:error, "status code 404"}
+      {:error, response} = Downstream.get(@error_url, context.io_device)
+
+      assert response.status_code == 404
     end
 
     test "accepts a configurable timeout", context do
       url = "#{@success_url}?sleep=5000"
 
-      assert Downstream.get(url, context.io_device, timeout: 1_000) == {:error, "request timeout"}
+      {:error, error} = Downstream.get(url, context.io_device, timeout: 1_000)
+
+      assert error.reason == :timeout
     end
   end
 
@@ -38,14 +47,15 @@ defmodule DownstreamTest do
     end
 
     test "successfully downloads a file with a get request", context do
-      io_device = Downstream.get!(@success_url, context.io_device)
+      response = Downstream.get!(@success_url, context.io_device)
 
-      assert io_device == context.io_device
-      assert StringIO.flush(io_device) == "200 OK"
+      assert response.device == context.io_device
+      assert response.status_code == 200
+      assert is_binary(StringIO.flush(response.device))
     end
 
     test "raises an error for an unsuccessful download", context do
-      assert_raise RuntimeError, "status code 404", fn ->
+      assert_raise Error, fn ->
         Downstream.get!(@error_url, context.io_device)
       end
     end
@@ -59,21 +69,25 @@ defmodule DownstreamTest do
     end
 
     test "successfully downloads a file with a post request", context do
-      {:ok, io_device} = Downstream.post(@success_url, context.io_device)
+      {:ok, response} = Downstream.post(@success_url, context.io_device)
 
-      assert io_device == context.io_device
-      assert StringIO.flush(io_device) == "200 OK"
+      assert response.device == context.io_device
+      assert response.status_code == 200
+      assert is_binary(StringIO.flush(response.device))
     end
 
     test "returns an error for an unsuccessful download", context do
-      assert Downstream.post(@error_url, context.io_device) == {:error, "status code 404"}
+      {:error, response} = Downstream.post(@error_url, context.io_device)
+
+      assert response.status_code == 404
     end
 
     test "accepts a configurable timeout", context do
       url = "#{@success_url}?sleep=5000"
 
-      assert Downstream.post(url, context.io_device, "", timeout: 1_000) ==
-               {:error, "request timeout"}
+      {:error, response} = Downstream.get(url, context.io_device, timeout: 1_000)
+
+      assert response.reason == :timeout
     end
   end
 
@@ -85,14 +99,15 @@ defmodule DownstreamTest do
     end
 
     test "successfully downloads a file with a post request", context do
-      io_device = Downstream.post!(@success_url, context.io_device)
+      response = Downstream.post!(@success_url, context.io_device)
 
-      assert io_device == context.io_device
-      assert StringIO.flush(io_device) == "200 OK"
+      assert response.device == context.io_device
+      assert response.status_code == 200
+      assert is_binary(StringIO.flush(response.device))
     end
 
     test "raises an error for an unsuccessful download", context do
-      assert_raise RuntimeError, "status code 404", fn ->
+      assert_raise Error, fn ->
         Downstream.post!(@error_url, context.io_device)
       end
     end

--- a/test/downstream_test.exs
+++ b/test/downstream_test.exs
@@ -1,13 +1,14 @@
 defmodule DownstreamTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Downstream
 
-  @tag timeout: 5_000
+  @tag timeout: 10_000
 
   alias Downstream.Error
 
-  @success_url "https://httpstat.us/200"
-  @error_url "https://httpstat.us/404"
+  @get_success_url "https://s3-us-west-2.amazonaws.com/downstream-test/downstream.txt"
+  @post_success_url "https://httpstat.us/200"
+  @error_url "https://s3-us-west-2.amazonaws.com/downstream-test/notfound.txt"
 
   describe "get/3" do
     setup _context do
@@ -17,7 +18,7 @@ defmodule DownstreamTest do
     end
 
     test "successfully downloads a file with a get request", context do
-      {:ok, response} = Downstream.get(@success_url, context.io_device)
+      {:ok, response} = Downstream.get(@get_success_url, context.io_device)
 
       assert response.device == context.io_device
       assert response.status_code == 200
@@ -27,13 +28,11 @@ defmodule DownstreamTest do
     test "returns an error for an unsuccessful download", context do
       {:error, response} = Downstream.get(@error_url, context.io_device)
 
-      assert response.status_code == 404
+      assert response.status_code == 403
     end
 
     test "accepts a configurable timeout", context do
-      url = "#{@success_url}?sleep=5000"
-
-      {:error, error} = Downstream.get(url, context.io_device, timeout: 1_000)
+      {:error, error} = Downstream.get(@get_success_url, context.io_device, timeout: 0)
 
       assert error.reason == :timeout
     end
@@ -47,7 +46,7 @@ defmodule DownstreamTest do
     end
 
     test "successfully downloads a file with a get request", context do
-      response = Downstream.get!(@success_url, context.io_device)
+      response = Downstream.get!(@get_success_url, context.io_device)
 
       assert response.device == context.io_device
       assert response.status_code == 200
@@ -69,7 +68,7 @@ defmodule DownstreamTest do
     end
 
     test "successfully downloads a file with a post request", context do
-      {:ok, response} = Downstream.post(@success_url, context.io_device)
+      {:ok, response} = Downstream.post(@post_success_url, context.io_device)
 
       assert response.device == context.io_device
       assert response.status_code == 200
@@ -79,13 +78,11 @@ defmodule DownstreamTest do
     test "returns an error for an unsuccessful download", context do
       {:error, response} = Downstream.post(@error_url, context.io_device)
 
-      assert response.status_code == 404
+      assert response.status_code == 405
     end
 
     test "accepts a configurable timeout", context do
-      url = "#{@success_url}?sleep=5000"
-
-      {:error, response} = Downstream.get(url, context.io_device, timeout: 1_000)
+      {:error, response} = Downstream.get(@get_success_url, context.io_device, timeout: 0)
 
       assert response.reason == :timeout
     end
@@ -99,7 +96,7 @@ defmodule DownstreamTest do
     end
 
     test "successfully downloads a file with a post request", context do
-      response = Downstream.post!(@success_url, context.io_device)
+      response = Downstream.post!(@post_success_url, context.io_device)
 
       assert response.device == context.io_device
       assert response.status_code == 200

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(timeout: 5_000)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+Downstream.start()
 ExUnit.start(timeout: 5_000)


### PR DESCRIPTION
### What & Why

- [x] Adds a `Downstream.Response` struct that is returned from the `get`, `post`, `get!` and `post!` methods, to provide headers, status code, and IO device.
- [x] Adds a `Downstream.Error` exception that is used to encapsulate invalid status codes and timeouts.