### PR TITLE
test(mimic): use mimic to stub downloads in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,6 @@ iex(3)> File.close(file)
 - Stream downloads via HTTP POST requests
 - Configurable request timeouts
 
-## Roadmap
-
-- [ ] Handle redirects
-- [ ] Allow custom configurations
-
 ## Development
 
 ### Running Tests

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,8 @@ defmodule Downstream.MixProject do
       {:dialyxir, "~> 0.5.0", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.8", only: [:test]},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
-      {:httpoison, "~> 1.0.0"}
+      {:httpoison, "~> 1.0.0"},
+      {:mimic, "~> 0.2", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -13,6 +13,7 @@
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
+  "mimic": {:hex, :mimic, "0.2.0", "66601fa5ce58db59e88fa0bef9d35d8169f11afcc3c8f0c77f911093f4469785", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []},
 }

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,6 @@
 Downstream.start()
-ExUnit.start(timeout: 5_000)
+
+Application.ensure_all_started(:mimic)
+Mimic.copy(Downstream.Download)
+
+ExUnit.start()


### PR DESCRIPTION
### What & Why

Stubs out download portion of tests and eliminates non-determinism/timeouts.